### PR TITLE
feat: Acrobat使用モードの自動フォールバック機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ C:\ExcelConversion
 - これにより、Adobe Acrobatを必ず経由してPDFが生成されるため、要件「Adobeを使うのは必須」を満たします。
 - 既存のAcrobatプロセス終了やCOMリトライ、オブジェクト解放など、安定動作のための対策も実装されています。
 
+### 自動フォールバック（Adobe失敗時の非Acrobatモード）
+
+- `config.json` に `UseAcrobat` フラグ（既定: `true`）を追加しました。
+- Acrobatの初期化（COM生成）や最終保存に失敗した場合、スクリプトは自動で `UseAcrobat` を `false` に書き換え、以降の処理は**非Acrobatモード**に切り替わります。
+- 非Acrobatモードでは、Excelが出力した一時PDFをそのまま最終保存先へコピーします。出力ディレクトリ・ファイル命名はAdobe使用時と同一です（`completed/pdf/<Excel名>/<Excel名>__<シート名>.pdf`）。
+- Acrobat環境が復旧した後に再度Acrobat経由に戻したい場合は、`config.json` の `UseAcrobat` を `true` に戻してください。
+
 ## 自動監視機能 (Auto Monitoring Feature)
 
 ### 概要

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "ScriptPath": "Convert-ExcelToPdf.ps1",
   "LogPath": "logs",
   "FileFilters": ["*.xlsx", "*.xls"],
+  "UseAcrobat": true,
   "Description": "Excel to PDF変換のファイル監視サービス設定",
   "Version": "1.0.0",
   "LastUpdated": "2025-01-22"


### PR DESCRIPTION
- `config.json` に `UseAcrobat` フラグを追加し、Acrobatの初期化や最終保存に失敗した場合に自動で非Acrobatモードに切り替える機能を実装
- Acrobatプロセスの確認・終了処理を条件付きで実行し、安定した動作を確保
- README.mdを更新し、自動フォールバック機能の詳細を追記

変更ファイル:
- Convert-ExcelToPdf.ps1: Acrobat使用モードの管理機能を追加
- config.json: `UseAcrobat` フラグを追加
- README.md: 自動フォールバック機能の説明を追加